### PR TITLE
修复和补充，为0.0.7.1做准备

### DIFF
--- a/src/main/resources/assets/sakura/lang/en_us.lang
+++ b/src/main/resources/assets/sakura/lang/en_us.lang
@@ -264,7 +264,7 @@ item.sakura.buggys_meat.name=Buggys Meat
 
 item.sakura.cooking_pot.name=Cooking Pot
 
-item.sakura.earl_grey_leaves=Earl Grey Leaves
+item.sakura.earl_grey_leaves.name=Earl Grey Leaves
 item.sakura.black_tea_leaves.name=Black Tea Leaves
 item.sakura.green_tea_leaves.name=Green Tea Leaves
 item.sakura.fruit_tea_leaves.name=Fruit Tea Leaves
@@ -399,6 +399,19 @@ fluid.whiskey=Whiskey
 fluid.liqueur=Liqueur
 fluid.cocoa_liqueur=Cocoa Liqueur
 
+#Tooltips
+item.sakura.kimono.texture.name=Kimono
+item.sakura.haori.texture.name=Haori
+
+#Keybinding
+key.categories.sakura=Sakura
+key.sakura.sheath_in=Retract Katana into Sheath
+
+#Chats
+sakura.katana.wrong_duel_shinai=You must hold a Shinai with BOTH hands.
+sakura.katana.wrong_duel=You shouldn't wield two Katanas with both hands.
+sakura.katana.sheath.not_empty_hand=You should pull out your Katana with an empty hand.
+
 #Container
 container.sakura.stonemortar=Stone Mortar
 container.sakura.campfirepot=Campfire Pot
@@ -409,6 +422,9 @@ barrel.contains.nonfluid=This barrel is empty
 #JEI Support
 jei.sakura.category.cooking_pot=Cooking Pot
 jei.sakura.category.mortar=Stone Mortar
+jei.sakura.category.barrel=Barrel
+jei.sakura.category.distillation=Distillation Barrel
+jei.sakura.category.liquid_item=Liquid to Bucket
 
 #Entities
 entity.sakura.Deer.name=Deer
@@ -416,6 +432,7 @@ entity.sakura.SamuraiIllager.name=Samurai Illager
 entity.Villager.wa_farmer=Japanese Farmer
 entity.Villager.wa_fisher=Japanese Fisher
 entity.Villager.wa_trader=Japanese Trader
+entity.Villager.wine_trader=Liquor Trader
 
 guide.sakura_guide.landing_text=There are many plants in this world. This book mainly describes things that must-see for harvesters
 

--- a/src/main/resources/assets/sakura/lang/zh_cn.lang
+++ b/src/main/resources/assets/sakura/lang/zh_cn.lang
@@ -381,7 +381,7 @@ item.sakura.glass_scorpion.name=天蝎
 item.sakura.glass_moscow_mule.name=莫斯科骡子
 item.sakura.glass_boilermaker.name=酒鬼炸弹
 
-#Fluid
+#液体方块
 fluid.food_oil=食用油
 fluid.grape_fluid=葡萄汁
 fluid.red_wine=红葡萄酒
@@ -399,30 +399,47 @@ fluid.whiskey=威士忌
 fluid.liqueur=利口酒
 fluid.cocoa_liqueur=可可利口酒
 
-#Container
+#物品信息
+item.sakura.kimono.texture.name=和服
+item.sakura.haori.texture.name=羽织
+
+#按键绑定
+key.categories.sakura=樱
+key.sakura.sheath_in=收刀入鞘
+
+#聊天提示信息
+sakura.katana.wrong_duel_shinai=竹刀必须双手握持。
+sakura.katana.wrong_duel=你不能双持打刀。
+sakura.katana.sheath.not_empty_hand=空出一只手才可以拔刀。
+
+#容器GUI
 container.sakura.stonemortar=石磨
 container.sakura.campfirepot=烹饪锅
 
 barrel.contains.fluid=这个桶含有%1$s液体
 barrel.contains.nonfluid=这个桶是空的
 
-#JEI Support
+#JEI条目
 jei.sakura.category.cooking_pot=烹饪锅
 jei.sakura.category.mortar=石磨
+jei.sakura.category.barrel=酿造桶
+jei.sakura.category.distillation=蒸馏桶
+jei.sakura.category.liquid_item=液体装桶
 
-#Entities
+#实体
 entity.sakura.Deer.name=鹿
 entity.sakura.SamuraiIllager.name=灾厄武士
 entity.Villager.wa_farmer=日本农民
 entity.Villager.wa_fisher=日本渔夫
 entity.Villager.wa_trader=日本商人
+entity.Villager.wine_trader=酒品贩子
 
 guide.sakura_guide.landing_text=世界上有许多作物。而本书主要收录收割者必须掌握的作物知识。
 
-itemGroup.sakura_tabs=樱花
+itemGroup.sakura_tabs=樱
 
 
-#Config
+#配置选项
 sakura.config.vanilla_weight=香草世界生成率
 sakura.config.vanilla_weight.tooltip=变更香草的生成率，数字越高生成越多。
 sakura.config.pepper_weight=胡椒世界生成率


### PR DESCRIPTION
补充了之前丢失的翻译，以及处理了新增的GUI和村民的语言条目。
这里有一处翻译我自己发挥了一下，
435行
`entity.Villager.wine_trader=Liquor Trader`
Wine一词按照喂鸡百科的解释特指葡萄发酵制成的酒精饮料，但是考虑到这个村民可能会卖各种各样的酒，故采用酒精饮料的泛称Liquor来代替。
其他地方暂时没有发现翻译疑点，经检查没有本地化遗漏。
//其实zh_cn的那个commit的标题也是“修复和补充，为0.0.7.1做准备”，但是打歪来就提交上去了，结果还改不了（