### PR TITLE
修改樱之打刀的配方

### DIFF
--- a/src/main/resources/assets/sakura/recipes/sakura_katana.json
+++ b/src/main/resources/assets/sakura/recipes/sakura_katana.json
@@ -3,15 +3,18 @@
   "pattern": [
     "  #",
     " # ",
-    "S  "
+    "S H"
   ],
   "key": {
     "#": {
-      "item": "sakura:sakura_diamond"
+       "item": "sakura:sakura_diamond"
     },
     "S": {
       "type": "forge:ore_dict",
-      "ore": "woodLumber"
+      "ore": "lumber"
+    },
+    "H": {
+      "item": "#TOOLFORGINGHAMMER"
     }
   },
   "result": {
@@ -19,3 +22,4 @@
     "count": 1
   }
 }
+


### PR DESCRIPTION
大概是出于两点考虑：
1. 目前（0.0.9.1版本）樱之打刀是无法合成的，将矿词 `woodLumber` 改为 `lumber` 似乎是可以解决这个问题的。
2. 与普通打刀需要锻造锤做个统一，增加锻造锤的使用场景。