### PR TITLE
Update jei-integration with correct project id so it will compile successfully.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     // at runtime, use the full JEI jar
     runtime "mezz.jei:jei_1.12.2:4.14.3.238"
 	
-	deobfCompile "curse.maven:jei-integration:2491927"
+	deobfCompile "curse.maven:jei-integration-265917:2491927"
 
     deobfCompile "slimeknights.mantle:Mantle:1.12-1.3.3.55"
 


### PR DESCRIPTION

The project id was not set for the jei-integration dependency so you could not build the project as is.